### PR TITLE
Typedef for prog_uchar because it doesn't work in recent Arduino versions

### DIFF
--- a/firmware/Arduino/libraries/ColorLCDShield/ColorLCDShield.h
+++ b/firmware/Arduino/libraries/ColorLCDShield/ColorLCDShield.h
@@ -18,6 +18,8 @@
 #define PHILIPS     0
 #define EPSON		1
 
+typedef unsigned char prog_uchar;
+
 //#include <WProgram.h>
 
 #include <inttypes.h>


### PR DESCRIPTION
As per Arduino 1.5.7 prog_uchar is no longer defined. See: http://forum.arduino.cc/index.php?topic=261093.0. Added typedef to fix this issue.
